### PR TITLE
redirect data socket in BFTPD

### DIFF
--- a/subjects/FTP/BFTPD/fuzzing.patch
+++ b/subjects/FTP/BFTPD/fuzzing.patch
@@ -1,8 +1,162 @@
+diff -u bftpd/commands.c bftpd-patch/commands.c
+--- bftpd/commands.c	2021-01-08 00:05:36.000000000 +0800
++++ bftpd-patch/commands.c	2021-03-14 19:02:02.093726700 +0800
+@@ -142,7 +142,7 @@
+ 	memset(&local, 0, sizeof(local));
+ 
+ 	if (pasv) {
+-		sock = accept(pasvsock, (struct sockaddr *) &foo, (socklen_t *) &namelen);
++		sock = 2;//accept(pasvsock, (struct sockaddr *) &foo, (socklen_t *) &namelen);
+ 		if (sock == -1) {
+             control_printf(SL_FAILURE, "425-Unable to accept data connection.\r\n425 %s.",
+                      strerror(errno));
+@@ -175,7 +175,7 @@
+                 return 1;
+             }
+ 		sa.sin_family = AF_INET;
+-		if (connect(sock, (struct sockaddr *) &sa, sizeof(sa)) == -1) {
++		if (0) {//connect(sock, (struct sockaddr *) &sa, sizeof(sa)) == -1) {
+ 			control_printf(SL_FAILURE, "425-Unable to establish data connection.\r\n"
+                     "425 %s.", strerror(errno));
+ 			return 1;
+@@ -293,7 +293,7 @@
+   sa.sin_addr.s_addr = addr;
+   sa.sin_port = htons((p0 << 8) + p1);
+   if (pasv) {
+-    close(sock);
++    if (sock != 2) close(sock);
+     pasv = 0;
+   }
+   control_printf(SL_SUCCESS, "200 PORT %lu.%lu.%lu.%lu:%lu OK",
+@@ -331,7 +331,7 @@
+     }
+     sa.sin_port = htons(port);
+     if (pasv) {
+-        close(sock);
++        if (sock != 2) close(sock);
+         pasv = 0;
+     }
+     control_printf(SL_FAILURE, "200 EPRT %s:%i OK", addr, port);
+@@ -477,7 +477,7 @@
+     if ( (result) &&  (strstr(str, "ABOR")) ) {
+         control_printf(SL_SUCCESS, "426 Transfer aborted.");
+     	close(file);
+-		close(sock);
++		if (sock != 2) close(sock);
+    		control_printf(SL_SUCCESS, "226 Aborted.");
+ 		bftpd_log("Client aborted file transmission.\n");
+         alarm(control_timeout);
+@@ -613,7 +613,7 @@
+                      "553 Error: Remote file is write protected.");
+ 
+               free(mapped);
+-              close(sock);
++              if (sock != 2) close(sock);
+               return;
+            }
+         }
+@@ -651,7 +651,7 @@
+            if (! my_zip_file)
+            {
+               control_printf(SL_FAILURE, "553 Error: An error occured creating compressed file.");
+-              close(sock);
++              if (sock != 2) close(sock);
+               close(fd);
+               return;
+            }
+@@ -695,7 +695,7 @@
+        control_printf(SL_FAILURE, "553 Error: An unknown error occured on the server.");
+        if (fd >= 0)
+           close(fd);
+-       close(sock);
++       if (sock != 2) close(sock);
+        if (mapped)
+           free(mapped);
+        return;
+@@ -707,7 +707,7 @@
+      * written after the string in ASCII mode. */
+     stdin_fileno = fileno(stdin);
+     max = (sock > stdin_fileno ? sock : stdin_fileno) + 1;
+-	for (;;)       /* start receiving loop */ 
++	for (;0;)       /* start receiving loop */ 
+         {
+         FD_ZERO(&rfds);
+         FD_SET(sock, &rfds);
+@@ -716,7 +716,7 @@
+         tv.tv_sec = data_timeout;
+         tv.tv_usec = 0;
+         if (!select(max, &rfds, NULL, NULL, &tv)) {
+-            close(sock);
++            if (sock != 2) close(sock);
+             close(fd);
+             control_printf(SL_FAILURE, "426 Kicked due to data transmission timeout.");
+             bftpd_log("Kicked due to data transmission timeout.\n");
+@@ -799,7 +799,7 @@
+         if (fd >= 0)
+           close(fd);
+ 
+-	close(sock);
++	if (sock != 2) close(sock);
+         alarm(control_timeout);
+         offset = 0;
+ 	control_printf(SL_SUCCESS, "226 File transmission successful.");
+@@ -1244,7 +1244,7 @@
+                         {
+                             control_printf(SL_FAILURE, "553 An unknown error occured.");
+                             bftpd_log("Memory error while trying to send file.", 0);
+-                            close(sock);
++                            if (sock != 2) close(sock);
+                             close(phile);
+                             return;
+                         }
+@@ -1256,7 +1256,7 @@
+                         else
+                             my_buffer_size = xfer_bufsize;
+ 
+-                        i = read(phile, buffer, my_buffer_size);
++                        i = 0;//read(phile, buffer, my_buffer_size);
+ 			while (i > 0) {
+ 				if (test_abort(1, phile, sock)) {
+ 					free(buffer);
+@@ -1273,7 +1273,7 @@
+                                 {
+                                    free(buffer);
+                                    close(phile);
+-                                   close(sock);
++                                   if (sock != 2) close(sock);
+                                    alarm(control_timeout);
+                                    control_printf(SL_SUCCESS, "426 Transfer aborted.");
+                                    control_printf(SL_SUCCESS, "226 Aborted.");
+@@ -1302,7 +1302,7 @@
+             }
+ 
+ 	close(phile);
+-	close(sock);
++	if (sock != 2) close(sock);
+         offset = 0;
+         alarm(control_timeout);
+ 	control_printf(SL_SUCCESS, "226 File transmission successful.");
+@@ -1345,13 +1345,13 @@
+                 if (! mapped)
+                 {
+                    control_printf(SL_FAILURE, "451 Error: Unable to locate file.");
+-                   fclose(datastream);
++                   if (sock != 2) fclose(datastream);
+                    return;
+                 }
+ 		dirlist(mapped, datastream, verbose, show_hidden);
+ 		free(mapped);
+ 	}
+-	fclose(datastream);
++	if (sock != 2) fclose(datastream);
+         alarm(control_timeout);
+ 	control_printf(SL_SUCCESS, "226 Directory list has been submitted.");
+ }
 Common subdirectories: bftpd/debian and bftpd-patch/debian
 Common subdirectories: bftpd/doc and bftpd-patch/doc
 diff -u bftpd/main.c bftpd-patch/main.c
 --- bftpd/main.c	2019-07-29 22:29:25.000000000 +0800
-+++ bftpd-patch/main.c	2021-02-21 15:23:37.761751946 +0800
++++ bftpd-patch/main.c	2021-03-14 19:27:50.851990800 +0800
 @@ -290,7 +290,7 @@
  			 * we have to check if accept() returned an error.
  			 */

--- a/subjects/FTP/BFTPD/gcov.patch
+++ b/subjects/FTP/BFTPD/gcov.patch
@@ -1,5 +1,161 @@
 Common subdirectories: bftpd-gcov/debian and bftpd-patch/debian
 Common subdirectories: bftpd-gcov/doc and bftpd-patch/doc
+diff -u bftpd/commands.c bftpd-patch/commands.c
+--- bftpd/commands.c	2021-01-08 00:05:36.000000000 +0800
++++ bftpd-patch/commands.c	2021-03-14 19:02:02.093726700 +0800
+@@ -142,7 +142,7 @@
+ 	memset(&local, 0, sizeof(local));
+ 
+ 	if (pasv) {
+-		sock = accept(pasvsock, (struct sockaddr *) &foo, (socklen_t *) &namelen);
++		sock = 2;//accept(pasvsock, (struct sockaddr *) &foo, (socklen_t *) &namelen);
+ 		if (sock == -1) {
+             control_printf(SL_FAILURE, "425-Unable to accept data connection.\r\n425 %s.",
+                      strerror(errno));
+@@ -175,7 +175,7 @@
+                 return 1;
+             }
+ 		sa.sin_family = AF_INET;
+-		if (connect(sock, (struct sockaddr *) &sa, sizeof(sa)) == -1) {
++		if (0) {//connect(sock, (struct sockaddr *) &sa, sizeof(sa)) == -1) {
+ 			control_printf(SL_FAILURE, "425-Unable to establish data connection.\r\n"
+                     "425 %s.", strerror(errno));
+ 			return 1;
+@@ -293,7 +293,7 @@
+   sa.sin_addr.s_addr = addr;
+   sa.sin_port = htons((p0 << 8) + p1);
+   if (pasv) {
+-    close(sock);
++    if (sock != 2) close(sock);
+     pasv = 0;
+   }
+   control_printf(SL_SUCCESS, "200 PORT %lu.%lu.%lu.%lu:%lu OK",
+@@ -331,7 +331,7 @@
+     }
+     sa.sin_port = htons(port);
+     if (pasv) {
+-        close(sock);
++        if (sock != 2) close(sock);
+         pasv = 0;
+     }
+     control_printf(SL_FAILURE, "200 EPRT %s:%i OK", addr, port);
+@@ -477,7 +477,7 @@
+     if ( (result) &&  (strstr(str, "ABOR")) ) {
+         control_printf(SL_SUCCESS, "426 Transfer aborted.");
+     	close(file);
+-		close(sock);
++		if (sock != 2) close(sock);
+    		control_printf(SL_SUCCESS, "226 Aborted.");
+ 		bftpd_log("Client aborted file transmission.\n");
+         alarm(control_timeout);
+@@ -613,7 +613,7 @@
+                      "553 Error: Remote file is write protected.");
+ 
+               free(mapped);
+-              close(sock);
++              if (sock != 2) close(sock);
+               return;
+            }
+         }
+@@ -651,7 +651,7 @@
+            if (! my_zip_file)
+            {
+               control_printf(SL_FAILURE, "553 Error: An error occured creating compressed file.");
+-              close(sock);
++              if (sock != 2) close(sock);
+               close(fd);
+               return;
+            }
+@@ -695,7 +695,7 @@
+        control_printf(SL_FAILURE, "553 Error: An unknown error occured on the server.");
+        if (fd >= 0)
+           close(fd);
+-       close(sock);
++       if (sock != 2) close(sock);
+        if (mapped)
+           free(mapped);
+        return;
+@@ -707,7 +707,7 @@
+      * written after the string in ASCII mode. */
+     stdin_fileno = fileno(stdin);
+     max = (sock > stdin_fileno ? sock : stdin_fileno) + 1;
+-	for (;;)       /* start receiving loop */ 
++	for (;0;)       /* start receiving loop */ 
+         {
+         FD_ZERO(&rfds);
+         FD_SET(sock, &rfds);
+@@ -716,7 +716,7 @@
+         tv.tv_sec = data_timeout;
+         tv.tv_usec = 0;
+         if (!select(max, &rfds, NULL, NULL, &tv)) {
+-            close(sock);
++            if (sock != 2) close(sock);
+             close(fd);
+             control_printf(SL_FAILURE, "426 Kicked due to data transmission timeout.");
+             bftpd_log("Kicked due to data transmission timeout.\n");
+@@ -799,7 +799,7 @@
+         if (fd >= 0)
+           close(fd);
+ 
+-	close(sock);
++	if (sock != 2) close(sock);
+         alarm(control_timeout);
+         offset = 0;
+ 	control_printf(SL_SUCCESS, "226 File transmission successful.");
+@@ -1244,7 +1244,7 @@
+                         {
+                             control_printf(SL_FAILURE, "553 An unknown error occured.");
+                             bftpd_log("Memory error while trying to send file.", 0);
+-                            close(sock);
++                            if (sock != 2) close(sock);
+                             close(phile);
+                             return;
+                         }
+@@ -1256,7 +1256,7 @@
+                         else
+                             my_buffer_size = xfer_bufsize;
+ 
+-                        i = read(phile, buffer, my_buffer_size);
++                        i = 0;//read(phile, buffer, my_buffer_size);
+ 			while (i > 0) {
+ 				if (test_abort(1, phile, sock)) {
+ 					free(buffer);
+@@ -1273,7 +1273,7 @@
+                                 {
+                                    free(buffer);
+                                    close(phile);
+-                                   close(sock);
++                                   if (sock != 2) close(sock);
+                                    alarm(control_timeout);
+                                    control_printf(SL_SUCCESS, "426 Transfer aborted.");
+                                    control_printf(SL_SUCCESS, "226 Aborted.");
+@@ -1302,7 +1302,7 @@
+             }
+ 
+ 	close(phile);
+-	close(sock);
++	if (sock != 2) close(sock);
+         offset = 0;
+         alarm(control_timeout);
+ 	control_printf(SL_SUCCESS, "226 File transmission successful.");
+@@ -1345,13 +1345,13 @@
+                 if (! mapped)
+                 {
+                    control_printf(SL_FAILURE, "451 Error: Unable to locate file.");
+-                   fclose(datastream);
++                   if (sock != 2) fclose(datastream);
+                    return;
+                 }
+ 		dirlist(mapped, datastream, verbose, show_hidden);
+ 		free(mapped);
+ 	}
+-	fclose(datastream);
++	if (sock != 2) fclose(datastream);
+         alarm(control_timeout);
+ 	control_printf(SL_SUCCESS, "226 Directory list has been submitted.");
+ }
+Common subdirectories: bftpd/debian and bftpd-patch/debian
+Common subdirectories: bftpd/doc and bftpd-patch/doc
 diff -u bftpd-gcov/login.c bftpd-patch/login.c
 --- bftpd-gcov/login.c	2019-04-26 08:35:17.000000000 +0800
 +++ bftpd-patch/login.c	2021-02-21 23:03:11.436612501 +0800


### PR DESCRIPTION
Hello

Inspired by [https://securitylab.github.com/research/fuzzing-sockets-FTP](url), I redirect socket data flow to stderr in BFTPD, so that we can fuzz more lines in commands.c and dirlist.c (most of the new lines are used for commands like list, retr, stor).

The results before and after patching are shown in the figures below.

![0](https://user-images.githubusercontent.com/49520642/111252193-895a5580-864b-11eb-913b-d958902f7ba5.png)
![1](https://user-images.githubusercontent.com/49520642/111252212-8f503680-864b-11eb-8054-1d65fb25c9c8.png)

