### PR TITLE
Add explicit WORKDIR, add optional support for deleting containers

### DIFF
--- a/scripts/execution/profuzzbench_exec_common.sh
+++ b/scripts/execution/profuzzbench_exec_common.sh
@@ -9,6 +9,9 @@ OUTDIR=$5     #name of the output folder created inside the docker container
 OPTIONS=$6    #all configured options for fuzzing
 TIMEOUT=$7    #time for fuzzing
 SKIPCOUNT=$8  #used for calculating coverage over time. e.g., SKIPCOUNT=5 means we run gcovr after every 5 test cases
+DELETE=$9
+
+WORKDIR="/home/ubuntu/experiments"
 
 #keep all container ids
 cids=()
@@ -36,6 +39,10 @@ index=1
 for id in ${cids[@]}; do
   printf "\n${FUZZER^^}: Collecting results from container ${id}"
   docker cp ${id}:/home/ubuntu/experiments/${OUTDIR}.tar.gz ${SAVETO}/${OUTDIR}_${index}.tar.gz > /dev/null
+  if [ ! -z $DELETE ]; then
+    printf "\nDeleting ${id}"
+    docker rm ${id} # Remove container now that we don't need it
+  fi
   index=$((index+1))
 done
 


### PR DESCRIPTION
Hi,

I have 2 small changes I want to propose. Both apply to the profuzzbench_exec_common.sh script. The first change is to explicitly define WORKDIR as "/home/ubuntu/experiments". I had already defined WORKDIR from previously working with aflnet, which also expects the user to set the WORKDIR directory; my WORKDIR and the WORKDIR required by the Docker container did not match up, so the container would simply quit before any fuzzing had occurred. So, I think it's better to simply set the WORKDIR in the script directly.

The second change is to add a 9th argument, DELETE. Basically, if it is set to any non-empty value, the spawned containers will be removed after the fuzzing sessions have finished. Of course, leaving it blank will resort to the default behavior.

I guess there may be other scripts that may benefit from these changes, but so far I've only looked at this one.