### PR TITLE
Update dockerfiles to use to 20.04

### DIFF
--- a/subjects/DAAP/forked-daapd/Dockerfile
+++ b/subjects/DAAP/forked-daapd/Dockerfile
@@ -1,6 +1,7 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 # Install common dependencies
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && \
     apt-get -y install sudo \ 
     apt-utils \
@@ -11,7 +12,8 @@ RUN apt-get -y update && \
     git \
     autoconf \
     libgnutls28-dev \
-    python-pip \
+    llvm \
+    python3-pip \
     nano \
     net-tools \
     vim \
@@ -26,7 +28,7 @@ RUN groupadd ubuntu && \
 
 RUN chmod 777 /tmp
 
-RUN pip install gcovr==4.2
+RUN pip3 install gcovr==4.2
 
 # Use ubuntu as default username
 USER ubuntu
@@ -34,9 +36,6 @@ WORKDIR /home/ubuntu
 
 # Import environment variable to pass as parameter to make (e.g., to make parallel builds with -j)
 ARG MAKE_OPT
-
-# Download and compile AFLNet
-ENV LLVM_CONFIG="llvm-config-6.0"
 
 # Set up fuzzers
 RUN git clone https://github.com/profuzzbench/aflnet.git && \
@@ -133,4 +132,3 @@ COPY --chown=ubuntu:ubuntu cov_script.sh ${WORKDIR}/cov_script
 COPY --chown=ubuntu:ubuntu run.sh ${WORKDIR}/run
 COPY --chown=ubuntu:ubuntu MP3 ${WORKDIR}/MP3
 COPY --chown=ubuntu:ubuntu forked-daapd.conf ${WORKDIR}/forked-daapd.conf
-

--- a/subjects/DICOM/Dcmtk/Dockerfile
+++ b/subjects/DICOM/Dcmtk/Dockerfile
@@ -1,6 +1,7 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 # Install common dependencies
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && \
     apt-get -y install sudo \ 
     apt-utils \
@@ -10,9 +11,10 @@ RUN apt-get -y update && \
     graphviz-dev \
     git \
     autoconf \
-    libgnutls-dev \
+    libgnutls28-dev \
     libssl-dev \
-    python-pip \
+    llvm \
+    python3-pip \
     nano \
     net-tools \
     vim \
@@ -27,7 +29,7 @@ RUN groupadd ubuntu && \
 
 RUN chmod 777 /tmp
 
-RUN pip install gcovr==4.2
+RUN pip3 install gcovr==4.2
 
 # Use ubuntu as default username
 USER ubuntu
@@ -35,9 +37,6 @@ WORKDIR /home/ubuntu
 
 # Import environment variable to pass as parameter to make (e.g., to make parallel builds with -j)
 ARG MAKE_OPT
-
-# Download and compile AFLNet
-ENV LLVM_CONFIG="llvm-config-3.8"
 
 # Set up fuzzers
 RUN git clone https://github.com/profuzzbench/aflnet.git && \
@@ -111,4 +110,3 @@ RUN cd $WORKDIR/dcmtk/build/bin && \
 RUN cd $WORKDIR/dcmtk-gcov/build/bin && \
     mkdir ACME_STORE && \
     cp $WORKDIR/dcmqrscp.cfg ./
-

--- a/subjects/DNS/Dnsmasq/Dockerfile
+++ b/subjects/DNS/Dnsmasq/Dockerfile
@@ -1,6 +1,7 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 # Install common dependencies
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && \
     apt-get -y install sudo \ 
     apt-utils \
@@ -10,9 +11,10 @@ RUN apt-get -y update && \
     graphviz-dev \
     git \
     autoconf \
-    libgnutls-dev \
+    libgnutls28-dev \
     libssl-dev \
-    python-pip \
+    llvm \
+    python3-pip \
     nano \
     net-tools \
     vim \
@@ -27,7 +29,7 @@ RUN groupadd ubuntu && \
 
 RUN chmod 777 /tmp
 
-RUN pip install gcovr==4.2
+RUN pip3 install gcovr==4.2
 
 # Use ubuntu as default username
 USER ubuntu
@@ -35,9 +37,6 @@ WORKDIR /home/ubuntu
 
 # Import environment variable to pass as parameter to make (e.g., to make parallel builds with -j)
 ARG MAKE_OPT
-
-# Download and compile AFLNet
-ENV LLVM_CONFIG="llvm-config-3.8"
 
 # Set up fuzzers
 RUN git clone https://github.com/profuzzbench/aflnet.git && \
@@ -95,5 +94,3 @@ COPY --chown=ubuntu:ubuntu dnsmasq.conf ${WORKDIR}/dnsmasq.conf
 
 RUN cp ${WORKDIR}/dnsmasq.conf /etc/ && \
     echo address=/test.com/5.5.5.5 | sudo tee -a /etc/dnsmasq.conf
-
-

--- a/subjects/DTLS/TinyDTLS/Dockerfile
+++ b/subjects/DTLS/TinyDTLS/Dockerfile
@@ -1,6 +1,7 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 # Install common dependencies
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && \
     apt-get -y install sudo \ 
     apt-utils \
@@ -10,9 +11,10 @@ RUN apt-get -y update && \
     graphviz-dev \
     git \
     autoconf \
-    libgnutls-dev \
+    libgnutls28-dev \
     libssl-dev \
-    python-pip \
+    llvm \
+    python3-pip \
     nano \
     net-tools \
     vim \
@@ -27,7 +29,7 @@ RUN groupadd ubuntu && \
 
 RUN chmod 777 /tmp
 
-RUN pip install gcovr==4.2
+RUN pip3 install gcovr==4.2
 
 # Use ubuntu as default username
 USER ubuntu
@@ -35,9 +37,6 @@ WORKDIR /home/ubuntu
 
 # Import environment variable to pass as parameter to make (e.g., to make parallel builds with -j)
 ARG MAKE_OPT
-
-# Download and compile AFLNet
-ENV LLVM_CONFIG="llvm-config-3.8"
 
 # Set up fuzzers
 RUN git clone https://github.com/profuzzbench/aflnet.git && \
@@ -91,4 +90,3 @@ RUN cd $WORKDIR && \
 COPY --chown=ubuntu:ubuntu in-dtls ${WORKDIR}/in-dtls
 COPY --chown=ubuntu:ubuntu cov_script.sh ${WORKDIR}/cov_script
 COPY --chown=ubuntu:ubuntu run.sh ${WORKDIR}/run
-

--- a/subjects/FTP/BFTPD/Dockerfile
+++ b/subjects/FTP/BFTPD/Dockerfile
@@ -1,6 +1,7 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 # Install common dependencies
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && \
     apt-get -y install sudo \ 
     apt-utils \
@@ -10,9 +11,10 @@ RUN apt-get -y update && \
     graphviz-dev \
     git \
     autoconf \
-    libgnutls-dev \
+    libgnutls28-dev \
     libssl-dev \
-    python-pip \
+    llvm \
+    python3-pip \
     nano \
     net-tools \
     vim \
@@ -27,7 +29,7 @@ RUN groupadd ubuntu && \
 
 RUN chmod 777 /tmp
 
-RUN pip install gcovr==4.2
+RUN pip3 install gcovr==4.2
 
 # Use ubuntu as default username
 USER ubuntu
@@ -35,9 +37,6 @@ WORKDIR /home/ubuntu
 
 # Import environment variable to pass as parameter to make (e.g., to make parallel builds with -j)
 ARG MAKE_OPT
-
-# Download and compile AFLNet
-ENV LLVM_CONFIG="llvm-config-3.8"
 
 # Set up fuzzers
 RUN git clone https://github.com/profuzzbench/aflnet.git && \
@@ -103,4 +102,3 @@ WORKDIR /home/ubuntu
 
 # For debugging purposes
 RUN apt-get -y install ftp
-

--- a/subjects/FTP/LightFTP/Dockerfile
+++ b/subjects/FTP/LightFTP/Dockerfile
@@ -1,6 +1,7 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 # Install common dependencies
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && \
     apt-get -y install sudo \ 
     apt-utils \
@@ -10,9 +11,10 @@ RUN apt-get -y update && \
     graphviz-dev \
     git \
     autoconf \
-    libgnutls-dev \
+    libgnutls28-dev \
     libssl-dev \
-    python-pip \
+    llvm \
+    python3-pip \
     nano \
     net-tools \
     vim \
@@ -27,7 +29,7 @@ RUN groupadd ubuntu && \
 
 RUN chmod 777 /tmp
 
-RUN pip install gcovr==4.2
+RUN pip3 install gcovr==4.2
 
 # Use ubuntu as default username
 USER ubuntu
@@ -35,9 +37,6 @@ WORKDIR /home/ubuntu
 
 # Import environment variable to pass as parameter to make (e.g., to make parallel builds with -j)
 ARG MAKE_OPT
-
-# Download and compile AFLNet
-ENV LLVM_CONFIG="llvm-config-3.8"
 
 # Set up fuzzers
 RUN git clone https://github.com/profuzzbench/aflnet.git && \
@@ -110,4 +109,3 @@ COPY --chown=ubuntu:ubuntu clean.sh ${WORKDIR}/ftpclean
 USER root
 RUN apt-get -y install ftp
 USER ubuntu
-

--- a/subjects/FTP/ProFTPD/Dockerfile
+++ b/subjects/FTP/ProFTPD/Dockerfile
@@ -1,6 +1,7 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 # Install common dependencies
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && \
     apt-get -y install sudo \ 
     apt-utils \
@@ -10,9 +11,10 @@ RUN apt-get -y update && \
     graphviz-dev \
     git \
     autoconf \
-    libgnutls-dev \
+    libgnutls28-dev \
     libssl-dev \
-    python-pip \
+    llvm \
+    python3-pip \
     nano \
     net-tools \
     vim \
@@ -27,7 +29,7 @@ RUN groupadd ubuntu && \
 
 RUN chmod 777 /tmp
 
-RUN pip install gcovr==4.2
+RUN pip3 install gcovr==4.2
 
 # Use ubuntu as default username
 USER ubuntu
@@ -35,9 +37,6 @@ WORKDIR /home/ubuntu
 
 # Import environment variable to pass as parameter to make (e.g., to make parallel builds with -j)
 ARG MAKE_OPT
-
-# Download and compile AFLNet
-ENV LLVM_CONFIG="llvm-config-3.8"
 
 # Set up fuzzers
 RUN git clone https://github.com/profuzzbench/aflnet.git && \
@@ -102,4 +101,3 @@ WORKDIR /home/ubuntu
 
 # For debugging purposes
 RUN apt-get -y install ftp
-

--- a/subjects/FTP/PureFTPD/Dockerfile
+++ b/subjects/FTP/PureFTPD/Dockerfile
@@ -1,6 +1,7 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 # Install common dependencies
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && \
     apt-get -y install sudo \ 
     apt-utils \
@@ -10,9 +11,10 @@ RUN apt-get -y update && \
     graphviz-dev \
     git \
     autoconf \
-    libgnutls-dev \
+    libgnutls28-dev \
     libssl-dev \
-    python-pip \
+    llvm \
+    python3-pip \
     nano \
     net-tools \
     vim \
@@ -35,9 +37,6 @@ WORKDIR /home/ubuntu
 
 # Import environment variable to pass as parameter to make (e.g., to make parallel builds with -j)
 ARG MAKE_OPT
-
-# Download and compile AFLNet
-ENV LLVM_CONFIG="llvm-config-3.8"
 
 # Set up fuzzers
 RUN git clone https://github.com/profuzzbench/aflnet.git && \
@@ -106,4 +105,3 @@ RUN useradd -rm -d /home/fuzzing -s /bin/bash -g ubuntu -G sudo -u 1001 fuzzing 
 
 # For debugging purposes
 RUN apt-get -y install ftp
-

--- a/subjects/RTSP/Live555/Dockerfile
+++ b/subjects/RTSP/Live555/Dockerfile
@@ -1,6 +1,7 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 # Install common dependencies
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && \
     apt-get -y install sudo \ 
     apt-utils \
@@ -10,9 +11,10 @@ RUN apt-get -y update && \
     graphviz-dev \
     git \
     autoconf \
-    libgnutls-dev \
+    libgnutls28-dev \
     libssl-dev \
-    python-pip \
+    llvm \
+    python3-pip \
     nano \
     net-tools \
     vim \
@@ -27,7 +29,7 @@ RUN groupadd ubuntu && \
 
 RUN chmod 777 /tmp
 
-RUN pip install gcovr==4.2
+RUN pip3 install gcovr==4.2
 
 # Use ubuntu as default username
 USER ubuntu
@@ -35,9 +37,6 @@ WORKDIR /home/ubuntu
 
 # Import environment variable to pass as parameter to make (e.g., to make parallel builds with -j)
 ARG MAKE_OPT
-
-# Download and compile AFLNet
-ENV LLVM_CONFIG="llvm-config-3.8"
 
 # Set up fuzzers
 RUN git clone https://github.com/profuzzbench/aflnet.git && \
@@ -99,4 +98,3 @@ COPY --chown=ubuntu:ubuntu in-rtsp ${WORKDIR}/in-rtsp
 COPY --chown=ubuntu:ubuntu rtsp.dict ${WORKDIR}/rtsp.dict
 COPY --chown=ubuntu:ubuntu cov_script.sh ${WORKDIR}/cov_script
 COPY --chown=ubuntu:ubuntu run.sh ${WORKDIR}/run
- 

--- a/subjects/SIP/Kamailio/Dockerfile
+++ b/subjects/SIP/Kamailio/Dockerfile
@@ -1,6 +1,7 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 # Install common dependencies
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && \
     apt-get -y install sudo \ 
     apt-utils \
@@ -10,9 +11,10 @@ RUN apt-get -y update && \
     graphviz-dev \
     git \
     autoconf \
-    libgnutls-dev \
+    libgnutls28-dev \
     libssl-dev \
-    python-pip \
+    llvm \
+    python3-pip \
     nano \
     net-tools \
     vim \
@@ -27,7 +29,7 @@ RUN groupadd ubuntu && \
 
 RUN chmod 777 /tmp
 
-RUN pip install gcovr==4.2
+RUN pip3 install gcovr==4.2
 
 # Use ubuntu as default username
 USER ubuntu
@@ -35,9 +37,6 @@ WORKDIR /home/ubuntu
 
 # Import environment variable to pass as parameter to make (e.g., to make parallel builds with -j)
 ARG MAKE_OPT
-
-# Download and compile AFLNet
-ENV LLVM_CONFIG="llvm-config-3.8"
 
 # Set up fuzzers
 RUN git clone https://github.com/profuzzbench/aflnet.git && \
@@ -107,4 +106,3 @@ COPY --chown=ubuntu:ubuntu run.sh ${WORKDIR}/run
 COPY --chown=ubuntu:ubuntu run_pjsip.sh ${WORKDIR}/run_pjsip
 COPY --chown=ubuntu:ubuntu kamailio-basic.cfg ${WORKDIR}/kamailio-basic.cfg
 COPY --chown=ubuntu:ubuntu StarWars3.wav ${WORKDIR}/StarWars3.wav
-

--- a/subjects/SMTP/Exim/Dockerfile
+++ b/subjects/SMTP/Exim/Dockerfile
@@ -1,6 +1,7 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 # Install common dependencies
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && \
     apt-get -y install sudo \ 
     apt-utils \
@@ -10,9 +11,10 @@ RUN apt-get -y update && \
     graphviz-dev \
     git \
     autoconf \
-    libgnutls-dev \
+    libgnutls28-dev \
     libssl-dev \
-    python-pip \
+    llvm \
+    python3-pip \
     nano \
     net-tools \
     vim \
@@ -27,7 +29,7 @@ RUN groupadd ubuntu && \
 
 RUN chmod 777 /tmp
 
-RUN pip install gcovr==4.2
+RUN pip3 install gcovr==4.2
 
 # Use ubuntu as default username
 USER ubuntu
@@ -35,9 +37,6 @@ WORKDIR /home/ubuntu
 
 # Import environment variable to pass as parameter to make (e.g., to make parallel builds with -j)
 ARG MAKE_OPT
-
-# Download and compile AFLNet
-ENV LLVM_CONFIG="llvm-config-3.8"
 
 # Set up fuzzers
 RUN git clone https://github.com/profuzzbench/aflnet.git && \
@@ -114,4 +113,3 @@ COPY --chown=ubuntu:ubuntu smtp.dict ${WORKDIR}/smtp.dict
 COPY --chown=ubuntu:ubuntu cov_script.sh ${WORKDIR}/cov_script
 COPY --chown=ubuntu:ubuntu run.sh ${WORKDIR}/run
 COPY --chown=ubuntu:ubuntu clean.sh ${WORKDIR}/clean
-

--- a/subjects/TLS/OpenSSL/Dockerfile
+++ b/subjects/TLS/OpenSSL/Dockerfile
@@ -1,6 +1,7 @@
-FROM ubuntu:16.04
+FROM ubuntu:20.04
 
 # Install common dependencies
+ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -y update && \
     apt-get -y install sudo \ 
     apt-utils \
@@ -10,9 +11,10 @@ RUN apt-get -y update && \
     graphviz-dev \
     git \
     autoconf \
-    libgnutls-dev \
+    libgnutls28-dev \
     libssl-dev \
-    python-pip \
+    llvm \
+    python3-pip \
     nano \
     net-tools \
     vim \
@@ -27,7 +29,7 @@ RUN groupadd ubuntu && \
 
 RUN chmod 777 /tmp
 
-RUN pip install gcovr==4.2
+RUN pip3 install gcovr==4.2
 
 # Use ubuntu as default username
 USER ubuntu
@@ -35,9 +37,6 @@ WORKDIR /home/ubuntu
 
 # Import environment variable to pass as parameter to make (e.g., to make parallel builds with -j)
 ARG MAKE_OPT
-
-# Download and compile AFLNet
-ENV LLVM_CONFIG="llvm-config-3.8"
 
 # Set up fuzzers
 RUN git clone https://github.com/profuzzbench/aflnet.git && \
@@ -96,4 +95,3 @@ COPY --chown=ubuntu:ubuntu in-tls ${WORKDIR}/in-tls
 COPY --chown=ubuntu:ubuntu tls.dict ${WORKDIR}/tls.dict
 COPY --chown=ubuntu:ubuntu cov_script.sh ${WORKDIR}/cov_script
 COPY --chown=ubuntu:ubuntu run.sh ${WORKDIR}/run
-


### PR DESCRIPTION
Hi

This PR updates docker files to use ubuntu version 20.04. Related to #3.

I haven't updated the docker file for OpenSSH yet, as the OpenSSH version in the repository wouldn't build under the newer version of libcrypto. The rest of the docker files build successfully under 20.04.