### PR TITLE
Fix profuzzbench_plot.py when only a single fuzzer is present

### DIFF
--- a/scripts/analysis/profuzzbench_plot.py
+++ b/scripts/analysis/profuzzbench_plot.py
@@ -24,6 +24,9 @@ def main(csv_file, put, runs, cut_off, step, out_file):
                          (df['fuzzer'] == fuzzer) & 
                          (df['cov_type'] == cov_type)]
 
+        if df1.empty:
+          continue
+
         mean_list.append((subject, fuzzer, cov_type, 0, 0.0))
         for time in range(1, cut_off + 1, step):
           cov_total = 0


### PR DESCRIPTION
This addresses #16:

```python
        df1 = df[(df['subject'] == subject) & 
                         (df['fuzzer'] == fuzzer) & 
                         (df['cov_type'] == cov_type)]
```
can be empty in some cases (e.g. only fuzzed with aflnet). Not extending the `mean_list` in those cases seems to be fine.